### PR TITLE
feat: added support for o1-preview and o1-mini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@ lerna-debug.log
 .DS_Store
 
 docs
+
+# Yarn
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/src/github_llms.ts
+++ b/src/github_llms.ts
@@ -77,6 +77,38 @@ export const openAIGpt4oMini = modelRef({
   configSchema: GenerationCommonConfigSchema,
 });
 
+export const openAIO1Preview = modelRef({
+  name: "github/o1-preview",
+  info: {
+    versions: ["o1-preview"],
+    label: "OpenAI - o1-preview",
+    supports: {
+      multiturn: true,
+      tools: true,
+      media: true,
+      systemRole: true,
+      output: ["text", "json"],
+    },
+  },
+  configSchema: GenerationCommonConfigSchema,
+});
+
+export const openAIO1Mini = modelRef({
+  name: "github/o1-mini",
+  info: {
+    versions: ["o1-mini"],
+    label: "OpenAI - o1-mini",
+    supports: {
+      multiturn: true,
+      tools: true,
+      media: true,
+      systemRole: true,
+      output: ["text", "json"],
+    },
+  },
+  configSchema: GenerationCommonConfigSchema,
+});
+
 export const metaLlama370bInstruct = modelRef({
   name: "github/meta-llama-3-70b-instruct",
   info: {
@@ -384,6 +416,8 @@ export const microsoftPhi35Mini128kInstruct = modelRef({
 export const SUPPORTED_GITHUB_MODELS: Record<string, any> = {
   "gpt-4o": openAIGpt4o,
   "gpt-4o-mini": openAIGpt4oMini,
+  "o1-preview": openAIO1Preview,
+  "o1-mini": openAIO1Mini,
   "meta-llama-3-70b-instruct": metaLlama370bInstruct,
   "meta-llama-3-8b-instruct": metaLlama38bInstruct,
   "meta-llama-3.1-405b-instruct": metaLlama31405bInstruct,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import {
   githubModel,
   openAIGpt4o,
   openAIGpt4oMini,
+  openAIO1Preview,
+  openAIO1Mini,
   metaLlama370bInstruct,
   metaLlama38bInstruct,
   metaLlama31405bInstruct,
@@ -38,6 +40,8 @@ import {
 export {
   openAIGpt4o,
   openAIGpt4oMini,
+  openAIO1Preview,
+  openAIO1Mini,
   metaLlama370bInstruct,
   metaLlama38bInstruct,
   metaLlama31405bInstruct,


### PR DESCRIPTION
_Before you submit a pull request, please make sure you have read and understood the [contribution guidelines](https://github.com/xavidop/genkitx-github/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/xavidop/genkitx-github/blob/main/CODE_OF_CONDUCT.md)._

**This pull request is related to:**

- [ ] A bug
- [x] A new feature
- [ ] Documentation
- [ ] Other (please specify)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/xavidop/genkitx-github/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/xavidop/genkitx-github/blob/main/CODE_OF_CONDUCT.md);
- [x] I have added new tests (for bug fixes/features);
- [x] I have added/updated the documentation (for bug fixes / features).

**Description:**
added support for o1-preview and o1-mini.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new model references: `openAIO1Preview` and `openAIO1Mini`, enhancing model availability for users.
	- Added support for multiturn interactions, tool usage, media support, and various output formats.
  
- **Chores**
	- Updated `.gitignore` to include Yarn-related files and directories, improving project file management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->